### PR TITLE
use vscode.workspace as cwd

### DIFF
--- a/ensime-server/src/main/scala/org/github/dragos/vscode/Main.scala
+++ b/ensime-server/src/main/scala/org/github/dragos/vscode/Main.scala
@@ -7,7 +7,7 @@ import java.io.FileOutputStream
 
 object Main extends LazyLogging {
   def main(args: Array[String]): Unit = {
-    val cwd = System.getenv("PWD")
+    val cwd = System.getProperty("vscode.workspace")
     logger.info(s"Starting server in $cwd")
     logger.info(s"Classpath: ${Properties.javaClassPath}")
 


### PR DESCRIPTION
At least under macOS, System.getenv("PWD"), new File("."), System.getProperty("user.dir") all return an empty string, causing the server to try and write to "/", which in turn makes it fail.

This should fix with the presumably intended behaviour, to start in the workspace directory, which is passed at startup anyway.