### PR TITLE
Use path.delimiter instead of ":" for java -cp.

### DIFF
--- a/scala/src/extension.ts
+++ b/scala/src/extension.ts
@@ -21,7 +21,7 @@ export function activate(context: ExtensionContext) {
 
   console.log("Workspace location is: " + workspace.rootPath)
 
-  let javaArgs = ["-Dvscode.workspace=" + workspace.rootPath, "-cp", toolsJar + ":" + assemblyPath, "org.github.dragos.vscode.Main"];
+  let javaArgs = ["-Dvscode.workspace=" + workspace.rootPath, "-cp", toolsJar + path.delimiter + assemblyPath, "org.github.dragos.vscode.Main"];
   // The debug options for the server
   let debugOptions = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000,quiet=y"];
 


### PR DESCRIPTION
Fixes #12. Windows needs a semicolon to find the two jars.

On Windows 10, before:
<img width="636" alt="vscode-scala-before" src="https://cloud.githubusercontent.com/assets/6420993/20072154/385c097e-a51f-11e6-9f08-7ea9ae6463ed.png">

After:
<img width="636" alt="vscode-scala-after" src="https://cloud.githubusercontent.com/assets/6420993/20072156/3a2e2bec-a51f-11e6-9716-92bb9d56750b.png">

