### PR TITLE
Update README to use newest npm libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ tl;dr
 $ sbt publishExtension
 $ cd scala
 $ npm install # only the first time, to download dependencies
-$ npm install -g tsc # if you don't have Typescript installed globally
+$ npm install -g vsce typescript # if you don't have Typescript installed globally
 $ vsce package
 ```
 
-You shuld see a file `ensime-scala-0.0.4.vsix` (or whatever version you are building). Now install it in Code by choosing `Install from VSIX` in the Extensions view.
+You should see a file `ensime-scala-0.0.4.vsix` (or whatever version you are building). Now install it in Code by choosing `Install from VSIX` in the Extensions view.
 
 
 The root Sbt project controls all the Scala parts of the build. The client is written in Typescript (it's really minimal) and lives under scala/. This one is built using Code's tools.


### PR DESCRIPTION
According to this warning, `tsc` is deprecated and should be replaced by `typescript`:
```
npm WARN deprecated tsc@1.20150623.0: You probably meant to instally 'typescript'. Run 'npm install typescript -g'
/usr/bin/tsc -> /usr/lib/node_modules/tsc/bin/tsc
/usr/bin/tsserver -> /usr/lib/node_modules/tsc/bin/tsserver
/usr/lib
└── tsc@1.20150623.0
```