### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ out/
 *.vsix
 *.log
 scala/server/ensimeServer-assembly*
+coursier

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Make sure you have an existing `.ensime` file before starting code in that direc
 tl;dr
 
 ```bash
-$ sbt publishExtension
+$ sbt publishLocal
 $ cd scala
 $ npm install # only the first time, to download dependencies
 $ npm install -g vsce typescript # if you don't have Typescript installed globally
@@ -46,10 +46,10 @@ The root Sbt project controls all the Scala parts of the build. The client is wr
 - ensime-lsp/ implements an Ensime based Scala language server
 - scala/ The typescript extension (eventually should migrate to Scala.js)
 
-`ensime-lsp` is what you will want to build most of the times. It's using `assembly` to build a fat jar, so the client can launch it as simply as possible.
+`ensime-lsp` is what you will want to build most of the times. It's launched with coursier by the client, for it to be as simply as possible.
 
-You should use `sbt publishExtension` which copies the fat jar into a directory under scala/server, so the client finds it easily.
+You should use `sbt publishLocal` which publishes the server under `~/.ivy2/local`, so the client finds it easily.
 
 ## Running
 
-You can open code inside the `scala/` directory and use `F5` to debug the extension. This picks up the changes in the server (make sure you copied the fat jar using `sbt publishExtension`!) and allows quick iteration.
+You can open code inside the `scala/` directory and use `F5` to debug the extension. This picks up the changes in the server (make sure you published it locally using `sbt publishLocal`!) and allows quick iteration.

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val commonSettings = Seq(
 )
 
 lazy val languageserver = project.
-  settings(commonSettings:_*).
+  settings(commonSettings).
   settings(
     libraryDependencies ++= Seq(
       "com.dhpcs" %% "play-json-rpc" % "1.3.0",
@@ -27,7 +27,7 @@ lazy val languageserver = project.
 lazy val ensimeServer = project.
   in(file("ensime-lsp")).
   dependsOn(languageserver).
-  settings(commonSettings:_*).
+  settings(commonSettings).
   settings(
     resolvers += Resolver.sonatypeRepo("snapshots"),
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ scalaVersion in ThisBuild := "2.11.8"
 
 lazy val commonSettings = Seq(
   organization := "com.github.dragos",
-  version := "0.1.0",
+  version := "0.1.1-SNAPSHOT",
   resolvers += "dhpcs at bintray" at "https://dl.bintray.com/dhpcs/maven",
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "2.2.6" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val languageserver = project.
     )
   )
 
-lazy val ensimeServer = project.
+lazy val `ensime-lsp` = project.
   in(file("ensime-lsp")).
   dependsOn(languageserver).
   settings(commonSettings).
@@ -44,7 +44,7 @@ lazy val ensimeServer = project.
 lazy val publishExtension = taskKey[Unit]("Copy ensimeServer assembly to extension")
 
 publishExtension := {
-  val assemblyFile = (assembly in ensimeServer).value
+  val assemblyFile = (assembly in `ensime-lsp`).value
   println(s"""Copying $assemblyFile to ${baseDirectory.value / "scala" / "server"}.""")
   IO.copyFile(assemblyFile, baseDirectory.value / "scala" / "server" / assemblyFile.getName)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -32,19 +32,5 @@ lazy val `ensime-lsp` = project.
     resolvers += Resolver.sonatypeRepo("snapshots"),
     libraryDependencies ++= Seq(
       "org.ensime" %% "core" % "2.0.0-SNAPSHOT"
-    ),
-    assemblyMergeStrategy in assembly := {
-      case PathList("org", "apache", "commons", "vfs2", xs @ _*) => MergeStrategy.first // assumes our classpath is setup correctly
-      case PathList("scala", "reflect", "io", xs @ _*) => MergeStrategy.first // assumes our classpath is setup correctly
-      case PathList("logback.groovy", xs @ _*) => MergeStrategy.first // assumes our classpath is setup correctly
-      case other => MergeStrategy.defaultMergeStrategy(other)
-    }
+    )
   )
-
-lazy val publishExtension = taskKey[Unit]("Copy ensimeServer assembly to extension")
-
-publishExtension := {
-  val assemblyFile = (assembly in `ensime-lsp`).value
-  println(s"""Copying $assemblyFile to ${baseDirectory.value / "scala" / "server"}.""")
-  IO.copyFile(assemblyFile, baseDirectory.value / "scala" / "server" / assemblyFile.getName)
-}

--- a/languageserver/src/main/resources/logback.groovy
+++ b/languageserver/src/main/resources/logback.groovy
@@ -1,9 +1,0 @@
-appender("FILE", FileAppender) {
-  file = "scala-langserver.log"
-  append = false
-  encoder(PatternLayoutEncoder) {
-    pattern = "%level %logger - %msg%n"
-  }
-}
-
-root(DEBUG, ["FILE"])

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 addSbtPlugin("org.ensime" % "sbt-ensime" % "1.12.0")

--- a/scala/package.json
+++ b/scala/package.json
@@ -79,7 +79,7 @@
         ]
     },
     "scripts": {
-        "vscode:prepublish": "tsc -p ./",
+        "vscode:prepublish": "curl -L -o coursier https://github.com/alexarchambault/coursier/raw/991b60ddbcb7d781c17a463f7af980f2dd888d4b/coursier && tsc -p ./",
         "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },

--- a/scala/src/extension.ts
+++ b/scala/src/extension.ts
@@ -12,12 +12,13 @@ export function activate(context: ExtensionContext) {
   console.info("Adding to classpath " + toolsJar);
 
   // The server is implemented in Scala
-  let assemblyPath = path.join(context.extensionPath, "./server/ensimeServer-assembly-0.1.0.jar")
-  console.info("Using " + assemblyPath);
+  let coursierPath = path.join(context.extensionPath, "./coursier")
+  console.info("Using coursier " + coursierPath);
 
   console.log("Workspace location is: " + workspace.rootPath)
 
-  let javaArgs = ["-Dvscode.workspace=" + workspace.rootPath, "-cp", toolsJar + path.delimiter + assemblyPath, "org.github.dragos.vscode.Main"];
+  let coursierArgs = ["launch", "-r", "https://dl.bintray.com/dhpcs/maven", "-r", "sonatype:snapshots", "-J", toolsJar, "com.github.dragos:ensime-lsp_2.11:0.1.1-SNAPSHOT", "-M", "org.github.dragos.vscode.Main"];
+  let javaArgs = ["-Dvscode.workspace=" + workspace.rootPath, "-jar", coursierPath].concat(coursierArgs);
   // The debug options for the server
   let debugOptions = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000,quiet=y"];
 


### PR DESCRIPTION
This PR replaces the assembly-based launch of the server with one using coursier. That has two advantages IMO:
- local development is a bit more lightweight, it now only requires a simple `sbt publishLocal` rather than an assembly generation, and
- that should make it easier to release the server: its scala modules can just be pushed to a repository (Central say). There's no need to make assemblies available somewhere. The server classpath is simply fetched using the coursier launcher.

This works by shipping the coursier launcher in the `vsix` file (it's downloaded during the `vsce package`), which is then used by the typescript code to launch the server.

The server version is currently hardcoded in the typescript code (set to `0.1.1-SNAPSHOT` in this PR), and would need to be edited prior to releases / version bumps.