### PR TITLE
Update TempFileStore.scala

### DIFF
--- a/ensime-lsp/src/main/scala/org/github/dragos/vscode/TempFileStore.scala
+++ b/ensime-lsp/src/main/scala/org/github/dragos/vscode/TempFileStore.scala
@@ -26,7 +26,7 @@ class TempFileStore(val path: String) extends LazyLogging {
     case RawFile(path) => Success(path)
     case ArchiveFile(jar, entry) => Try {
       logger.info(s"Extracting $jar!$entry to $rootPath")
-      val uri = URI.create(s"jar:file:$jar")
+      val uri = URI.create(s"jar:${jar.toFile.toURI.toString}")
       val zipFile = FileSystems.newFileSystem(uri, new java.util.HashMap[String, String])
       val zipFilePath = zipFile.getPath(entry)
       val targetPath = if (entry.startsWith("/")) entry.drop(1) else entry


### PR DESCRIPTION
Fixes following error in Windows (backslash not supported in file URI protocol):
[2017-04-04 07:30:04,317] ERROR org.github.dragos.vscode.EnsimeLanguageServer - Couldn't retrieve hyperlink target file java.lang.IllegalArgumentException: Illegal character in opaque part at index 11: jar:file:D:\temp\.ivy2\cache\org.scala-lang\scala-library\srcs\scala-library-2.11.9-sources.jar