### PR TITLE
Convert URI to OS specific file path

### DIFF
--- a/ensime-lsp/src/main/scala/org/github/dragos/vscode/EnsimeLanguageServer.scala
+++ b/ensime-lsp/src/main/scala/org/github/dragos/vscode/EnsimeLanguageServer.scala
@@ -6,6 +6,7 @@ import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.URI
+import java.nio.file.Paths
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -159,7 +160,7 @@ class EnsimeLanguageServer(in: InputStream, out: OutputStream) extends LanguageS
 
     for {
       doc <- documentManager.allOpenDocuments
-      path = new URI(doc.uri).getRawPath()
+      path = Paths.get(new URI(doc.uri)).toString
     } connection.publishDiagnostics(doc.uri, byFile.get(path).toList.flatten.map(toDiagnostic))
   }
 


### PR DESCRIPTION
This fixes the diagnostic notifications for Windows, and will hopefully do the right thing for other platforms too.