### PR TITLE
Only start the VSCode extension when a .ensime file exists

### DIFF
--- a/scala/package.json
+++ b/scala/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Scala Language Server",
 	"description": "A Scala language server based on Ensime",
 	"icon": "images/scala-logo.png",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"repository": {
 		"url": "https://github.com/dragos/dragos-vscode-scala"
 	},
@@ -18,7 +18,7 @@
 		"Languages"
 	],
 	"activationEvents": [
-		"onLanguage:scala",
+		"workspaceContains:.ensime",
 		"onCommand:sbt.update",
 		"onCommand:sbt.compile",
 		"onCommand:sbt.run",


### PR DESCRIPTION
The extension is useless without it, and this avoids conflicts with
other extensions like the Dotty Language Server (which will only start
when a .dotty-ide.json file is present after
https://github.com/lampepfl/dotty/pull/2777)