### PR TITLE
Fix loadConfig error on Windows (issue #60)

### DIFF
--- a/ensime-lsp/src/main/scala/org/github/dragos/vscode/EnsimeLanguageServer.scala
+++ b/ensime-lsp/src/main/scala/org/github/dragos/vscode/EnsimeLanguageServer.scala
@@ -84,7 +84,8 @@ class EnsimeLanguageServer(in: InputStream, out: OutputStream) extends LanguageS
   }
 
   def loadConfig(ensimeFile:File): Config = {
-    val config = s"""ensime.config = "${ensimeFile.toString}" """
+    // Replace occurances of \ with /, otherwise ConfigFactory.parseString() fails on Windows due to path separators
+    val config = s"""ensime.config = "${ensimeFile.toString}" """.replace('\\', '/')
     val fallback = ConfigFactory.parseString(config)
     ConfigFactory.load().withFallback(fallback)
   }  


### PR DESCRIPTION
Fixes issue #60. ConfigFactory.parseString errors out if the string contains a path with Windows path separators so replace all occurrances of \ with /.

This should not affect other platforms as far as I can tell.