### PR TITLE
Fix for issue #60, ensime.config file name for Windows

### DIFF
--- a/ensime-lsp/src/main/scala/org/github/dragos/vscode/EnsimeLanguageServer.scala
+++ b/ensime-lsp/src/main/scala/org/github/dragos/vscode/EnsimeLanguageServer.scala
@@ -84,7 +84,9 @@ class EnsimeLanguageServer(in: InputStream, out: OutputStream) extends LanguageS
   }
 
   def loadConfig(ensimeFile:File): Config = {
-    val config = s"""ensime.config = "${ensimeFile.toString}" """
+    val fileName = ensimeFile.getCanonicalFile.toString.replaceAllLiterally("\\","/")
+    val config = s"""ensime.config = "$fileName" """
+    logger.debug(config)
     val fallback = ConfigFactory.parseString(config)
     ConfigFactory.load().withFallback(fallback)
   }  


### PR DESCRIPTION
Not sure it's the best way to handle it, but given that EnsimeConfig expects a string file name in ensime.config, I had to create a platform independent file name string. Tested and works in both Linux and Windows.