### PR TITLE
Modified snippets to use placeholders

### DIFF
--- a/scala/snippets/scala.json
+++ b/scala/snippets/scala.json
@@ -10,15 +10,15 @@
 		"prefix": "resolvers",
 		"body": [
 			"resolvers += ",
-  		"	\"${name: Repository name}\" at \"${url: Url where the repository is defined}\""
+			"\"${1:Repository name}\" at \"${2:Url where the repository is defined}\""
 		]
 	},
 
 	"New ScalaTest suite": {
 		"prefix": "suite",
 		"body": [
-			"class ${MyTestSuite} extends FunSuite {",
-			"  test(\"${test name}\") {",
+			"class ${1:MyTestSuite} extends FunSuite {",
+			"  test(\"${2:Test name}\") {",
 			"  }",
 			"}"
 		]


### PR DESCRIPTION
VSCode kept giving a warning related to a snippet:

> The "New ScalaTest suite"-snippet very likely confuses snippet-variables and snippet-placeholders. See https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details.

So I went ahead and fixed the warning by changing both that and the "Add Sbt resolver" snippet to use placeholders instead. It makes using the snippets more useful too as you can just tab through the places where you need to type in stuff.