### PR TITLE
Declare configuration settings in manifest

### DIFF
--- a/scala/package.json
+++ b/scala/package.json
@@ -31,6 +31,22 @@
 	],
 	"main": "./out/src/extension",
 	"contributes": {
+		"configuration": {
+			"type": "object",
+			"title": "Scala Language Server configuration",
+			"properties": {
+				"scalaLanguageServer.logLevel": {
+					"type": ["string", "null"],
+					"default": null,
+					"description": "Log level of the Scala Language Server. Possible values are \"DEBUG\", \"ERROR\", \"INFO\", and \"WARN\"."
+				},
+				"scalaLanguageServer.heapSize": {
+					"type": ["string"],
+					"default": "768m",
+					"description": "Heap size used by the Scala Language Server. For example \"512m\" or \"4G\"."
+				}
+			}
+		},
 		"languages": [
 			{
 				"id": "scala",

--- a/scala/package.json
+++ b/scala/package.json
@@ -37,7 +37,7 @@
 			"properties": {
 				"scalaLanguageServer.logLevel": {
 					"type": ["string", "null"],
-					"default": null,
+					"default": "INFO",
 					"description": "Log level of the Scala Language Server. Possible values are \"DEBUG\", \"ERROR\", \"INFO\", and \"WARN\"."
 				},
 				"scalaLanguageServer.heapSize": {


### PR DESCRIPTION
@dragos

- Fix "Unknown configuration settings" error as reported in #70 by @Blaisorblade.
- Set default value of `scalaLanguageServer.logLevel` to `INFO`