### PR TITLE
Correct the version number of the `scala-json-rpc` dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val languageserver = project.
   settings(commonSettings).
   settings(
     libraryDependencies ++= Seq(
-      "com.dhpcs" %% "scala-json-rpc" % "2.0.1",
+      "com.dhpcs" %% "scala-json-rpc" % "0.9.3",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
       "org.slf4j" % "slf4j-api" % "1.7.21",
       "ch.qos.logback" %  "logback-classic" % "1.1.7",


### PR DESCRIPTION
Correct the version number of the `scala-json-rpc` dependency to the latest available version, from a version that does not exist.