### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/scala/src/extension.ts
+++ b/scala/src/extension.ts
@@ -75,7 +75,10 @@ export async function activate(context: ExtensionContext) {
   // Options to control the language client
   let clientOptions: LanguageClientOptions = {
     // Register the server for plain text documents
-    documentSelector: ['scala'],
+    documentSelector: [
+      { language: 'scala', scheme: 'file' },
+      { language: 'scala', scheme: 'untitled' }
+    ],
     synchronize: {
       // // Synchronize the setting section 'languageServerExample' to the server
       // configurationSection: 'languageServerExample',


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Scala, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the Scala extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*